### PR TITLE
kill the allCallSongs global variable by not fetching spotify data until we're done processing last.fm api responses

### DIFF
--- a/public/scripts/scripts.js
+++ b/public/scripts/scripts.js
@@ -1,5 +1,5 @@
 //This function gets a list of the user's playlists.
-function getPlaylists(access_token) {
+function getPlaylists(access_token, allCallSongs) {
   $.ajax({
     url: 'https://api.spotify.com/v1/me/playlists',
     headers: {
@@ -7,13 +7,13 @@ function getPlaylists(access_token) {
     },
     success: function(response) {
       $(".recommendations").show();
-      generatePlaylistDropdown(response.items);
+      generatePlaylistDropdown(response.items, allCallSongs);
     }
   });
 }
 
 // this function takes the playlists from getPlaylists and writes each title to the playlist selector dropdown.
-function generatePlaylistDropdown(playlists){
+function generatePlaylistDropdown(playlists, allCallSongs){
   playlists.map(function(playlist){
     var list = "<option value=" + playlist.id + " class='playlistItem'>" + playlist.name + "</option>"
     document.getElementById('playlistList').innerHTML += list;
@@ -21,13 +21,13 @@ function generatePlaylistDropdown(playlists){
   $('#playlistList').on('change', function() {
     $("#trackList").children().remove();
     var access_token = localStorage.getItem("access_token");
-    var playListTracks = getPlaylistTracks(access_token);
+    var playListTracks = getPlaylistTracks(access_token, allCallSongs);
     console.log(playListTracks);
   })
 }
 
 //This function will use the access token to retrieve a list of the songs in a given playlist.
-function getPlaylistTracks(access_token, request_url, playListTracks){
+function getPlaylistTracks(access_token, allCallSongs, request_url, playListTracks){
   var url = request_url || 'https://api.spotify.com/v1/playlists/' + $('select option:selected').val() + '/tracks'
   var playListTracks = (playListTracks || []);
   $.ajax({
@@ -36,33 +36,32 @@ function getPlaylistTracks(access_token, request_url, playListTracks){
       'Authorization':'Bearer ' + access_token
     },
     success: function(response) {
-      var tracks = (generateTrackList(response.items));
+      var tracks = generateTrackList(response.items, allCallSongs);
       console.log(tracks);
       tracks.map(function(track){
         playListTracks.push(track);
-        writePlayListToPanel(track);
+        writePlayListToPanel(track, playListTracks);
       })
       console.log(playListTracks);
-      // console.log(playListTracks);
       if(response.next) {
-        getPlaylistTracks(access_token, response.next, playListTracks);
+        getPlaylistTracks(access_token, allCallSongs, response.next, playListTracks);
       }
     }
   });
   return(playListTracks);
 }
 
-function writePlayListToPanel(track){
+function writePlayListToPanel(track, playListTracks){
   console.log(track);
   var list = "<li id=\"" + track.track.id + "\" class='playlistItem'>" + track.track.name + "<br><span class=\"trackArtist\"> by " + track.track.artists[0].name + "</span></li>"
   document.getElementById('trackList').innerHTML += list;
   $('li.playlistItem').click(function() {
-    displayTrackStats(idMatcher(this.id));
+    displayTrackStats(idMatcher(this.id, playListTracks));
   });
 }
 
 // this function goes over every track and writes it to the list pane and adds an onclick listener to each track which will check the playcount and write the track's metadata to the infopane
-function generateTrackList(tracks){
+function generateTrackList(tracks, allCallSongs){
   var trackBatch = [];
   tracks.map(function(track){
     // writePlayListToPanel(track);
@@ -76,8 +75,7 @@ function generateTrackList(tracks){
       spanText: "four weeks"}
     trackBatch.push(track);
   });
-  return(developPlayListStats(allCallSongs, trackBatch));
-  $('#controlPanel').show();
+  return developPlayListStats(allCallSongs, trackBatch);
 }
 
 function developPlayListStats(allCallSongs, trackBatch){
@@ -102,10 +100,10 @@ function developPlayListStats(allCallSongs, trackBatch){
     }
   }
   console.log(trackBatch);
-  return(trackBatch);
+  return trackBatch;
 };
 
-function idMatcher(identification){
+function idMatcher(identification, playListTracks){
   for (i = 0; i <= playListTracks.length; i++){
     if (identification == playListTracks[i].track.id){
       console.log('id match!');

--- a/public/scripts/setup.js
+++ b/public/scripts/setup.js
@@ -2,8 +2,8 @@ function initializeUser(access_token, refresh_token){
   // checkForExistingHistory();
   var userLastId = $("#lastId").val();
   localStorage.setItem("userLastId", userLastId);
+	// XXX maybe `getTrackForUser()` would be better named as `getLastFmHistory()` or similar?
   getTrackForUser(getFourWeeks(), getYesterday());
-  getPlaylists(access_token);
   $("#authenticatorPanel").hide();
   $("#overlay").hide();
   $("#playlistFetcher").show();


### PR DESCRIPTION
the main trick here is to wait until we're done getting responses to our last.fm api requests before we start kicking off spotify requests and building playlist dropdowns with event handlers and templating code that requires last.fm data in order to function.

note that this means that the playlist dropdown will now be empty for several seconds until our last.fm history has been processed. this could be mitigated by:

1. disabling the dropdown until it's been populated and having it say "please wait" or something, then (in an `else` clause of the `if(response.next)` if statement in the `success` function in `getPlaylistTracks()`?) enabling it once we're done processing spotify api respones
1. (eventually!) using localstorage to cache last.fm history so that the app initializes relatively instantly after the first pageload instead of always fetching the entire 4-week last.fm history

i've clicked around and verified that the app looks sane locally on my machine, but you know it better than i do - if i missed anything, or if my approach seems insane, or if you see bugs or have feedback / etc, please say so!