### PR TITLE
Remove old event listeners from control-panel buttons when the user switches playlists

### DIFF
--- a/public/scripts/statistics.js
+++ b/public/scripts/statistics.js
@@ -1,9 +1,21 @@
 var trackListSorted = false;
 var currentRange = "fourWeekPlays"
 
+const BUTTON_IDS = [
+  'sortByMostPlays',
+  'sortByFewestPlays',
+  'sortByNative',
+  'fourWeekButton',
+  'twoWeekButton',
+  'oneWeekButton'
+];
 
-// JR: here is my playlist control initializer. I try to pass PLT to it every time I pull a ne PL's Ts, in order to manipulate that Pl's data. It seems like if I call it in the wrong place (as I tried on statistics.js 76, and commented out), it'll start looping over and over, and if you click the buttons enough it'll hang indefinitely.
+
 function initializePlayListControl(playListTracks){
+  BUTTON_IDS.forEach(function(buttonId) {
+    $('#' + buttonId).off('click');
+  });
+
   console.log(playListTracks[0].track.name);
   $('#sortByMostPlays').click(function(){
     console.log(playListTracks[0].track.name);
@@ -11,29 +23,21 @@ function initializePlayListControl(playListTracks){
     $('button').removeClass('activeSort');
     $(this).addClass('activeSort');
     redrawTrackList(playListTracks);
-    // initializePlayListControl(playListTracks);
-
-  })
+  });
 
   $('#sortByFewestPlays').click(function(){
     trackListSorted = "byBottom";
     $('button').removeClass('activeSort');
     $(this).addClass('activeSort');
-    restoreSort(playListTracks);
     redrawTrackList(playListTracks);
-    // initializePlayListControl(playListTracks);
-
-  })
+  });
 
   $("#sortByNative").click(function(){
     trackListSorted = "byNative";
     $('button').removeClass('activeSort');
     $(this).addClass('activeSort');
-    restoreSort(playListTracks);
     redrawTrackList(playListTracks);
-    // initializePlayListControl(playListTracks);
-
-  })
+  });
 
   // this function manipulates the playcount stat and $('#dateRange') to reflect the previous four weeks.
   $('#fourWeekButton').click(function(){
@@ -41,9 +45,8 @@ function initializePlayListControl(playListTracks){
     $('button').removeClass('activeSpan');
     $(this).addClass('activeSpan');
     updateActiveStat(playListTracks, "fourWeekPlays", "four weeks");
-    restoreSort(playListTracks);
     redrawTrackList(playListTracks);
-  })
+  });
 
   // this function manipulates the playcount stat and $('#dateRange') to reflect the previous two weeks.
   $('#twoWeekButton').click(function(){
@@ -51,9 +54,8 @@ function initializePlayListControl(playListTracks){
     $('button').removeClass('activeSpan');
     $(this).addClass('activeSpan');
     updateActiveStat(playListTracks, "twoWeekPlays", "two weeks");
-    restoreSort(playListTracks);
     redrawTrackList(playListTracks);
-  })
+  });
 
   // this function manipulates the playcount stat and $('#dateRange') to reflect the previous week.
   $('#oneWeekButton').click(function(){
@@ -61,19 +63,19 @@ function initializePlayListControl(playListTracks){
     $('button').removeClass('activeSpan');
     $(this).addClass('activeSpan');
     updateActiveStat(playListTracks, "oneWeekPlays", "week");
-    restoreSort(playListTracks);
     redrawTrackList(playListTracks);
-  })
+  });
 }
 
-// JR - This little guy seems to be the root of the issue, or at least where my bugs make themselves apparent. Most specifically, if you load up a playlist and adjust the sort order, then call a new playlist and change that one's sort order, the previous playlist gets drawn to the playlist panel on the left, and in our console we get an error at line 76, "can't read property "top" of undefined"
-
 function redrawTrackList(playListTracks){
+  restoreSort(playListTracks);
+
   console.log(playListTracks);
   $("#trackList").children().remove();
+
   writePlayListToPanel(playListTracks);
-  // TODO: w/o initializePLControl here, the previous plt remains active when redrawing the playlist based on top/bottom, and shows the last pl used. With this line here, the listeners appear to be stacking. I may need to remove listeners from my playlist buttons, then re-initialize?
-  // initializePlayListControl(playListTracks);
+  initializePlayListControl(playListTracks);
+
   $("#" + activeTrack).addClass('activeTrack');
   // Here we call a variable to offset the control panel above the tracklist, then scroll to the active track after a redraw.
   if (activeTrack !== null){


### PR DESCRIPTION
i'm pretty sure this does what you want, but please sanity-check the code and test it out interactively, i'm in a weird library with astonishingly bad wifi so i wasn't super-able to do a lot of interactive testing on this. also moved restoreSort into redrawTrackList since it looks like the former is called every time you call the latter, but feel free to undo that change if you think it's incorrect, i didn't 100% confirm that that was a sane thing to do. let me know if this didn't do what you were hoping for!